### PR TITLE
Mapillary map features everywhere

### DIFF
--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -14,7 +14,6 @@ var viewercss = 'mapillary-js/mapillary.min.css';
 var viewerjs = 'mapillary-js/mapillary.min.js';
 var clientId = 'NzNRM2otQkR2SHJzaXJmNmdQWVQ0dzo1ZWYyMmYwNjdmNDdlNmVi';
 var mapFeatureConfig = {
-    organizationKey: 'FI3NAFfzQQgdF081TRdgTy',
     values: [
         'construction--flat--crosswalk-plain',
         'marking--discrete--crosswalk-zebra',
@@ -372,8 +371,8 @@ export default {
     loadMapFeatures: function(projection) {
         // if we are looking at signs, we'll actually need to fetch images too
         loadTiles('images', apibase + 'images?sort_by=key', projection);
-        loadTiles('points', apibase + 'map_features?layers=points&min_nbr_image_detections=2&sort_by=key&shapes_by_organization_keys=' + mapFeatureConfig.organizationKey + '&' + 'values=' + mapFeatureConfig.values + '&', projection);
-        loadTiles('image_detections', apibase + 'image_detections?layers=points&sort_by=key&shapes_by_organization_keys=' + mapFeatureConfig.organizationKey + '&' + 'values=' + mapFeatureConfig.values + '&', projection);
+        loadTiles('points', apibase + 'map_features?layers=points&min_nbr_image_detections=2&sort_by=key&values=' + mapFeatureConfig.values + '&', projection);
+        loadTiles('image_detections', apibase + 'image_detections?layers=points&sort_by=key&values=' + mapFeatureConfig.values + '&', projection);
     },
 
 

--- a/modules/ui/sections/photo_overlays.js
+++ b/modules/ui/sections/photo_overlays.js
@@ -4,7 +4,6 @@ import {
 
 import { t } from '../../core/localizer';
 import { uiTooltip } from '../tooltip';
-import { svgIcon } from '../../svg/icon';
 import { uiSection } from '../section';
 
 export function uiSectionPhotoOverlays(context) {
@@ -92,17 +91,6 @@ export function uiSectionPhotoOverlays(context) {
                 if (id === 'mapillary-signs') id = 'photo_overlays.traffic_signs';
                 return t(id.replace(/-/g, '_') + '.title');
             });
-
-        labelEnter
-            .filter(function(d) { return d.id === 'mapillary-map-features'; })
-            .append('a')
-            .attr('class', 'request-data-link')
-            .attr('target', '_blank')
-            .attr('tabindex', -1)
-            .call(svgIcon('#iD-icon-out-link', 'inline'))
-            .attr('href', 'https://mapillary.github.io/mapillary_solutions/data-request')
-            .append('span')
-            .text(t('mapillary_map_features.request_data'));
 
 
         // Update


### PR DESCRIPTION
Hello, this PR makes Mapillary map features available everywhere.

### Changes
- Updates the URL used to fetch all map features (documentation here: https://www.mapillary.com/developer/api-documentation/#map-features)
- Removes the "Request data" button which is now obsolete

Let me know if you have any questions or suggestions.